### PR TITLE
Remove createJSModules - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/io/callstack/react_native_material_palette/MaterialPalettePackage.kt
+++ b/android/src/main/java/io/callstack/react_native_material_palette/MaterialPalettePackage.kt
@@ -10,8 +10,8 @@ import com.facebook.react.uimanager.ViewManager
 import java.util.*
 
 class MaterialPalettePackage : ReactPackage {
-
-    override fun createJSModules(): MutableList<Class<out JavaScriptModule>> = Collections.emptyList()
+    
+    fun createJSModules(): MutableList<Class<out JavaScriptModule>> = Collections.emptyList()
 
     override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule>
             = mutableListOf(MaterialPaletteModule(reactContext))


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. This is backwards compatible according to my tests.