### PR TITLE
chore: extract colors from custom image in example app

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "expo": "~54.0.32",
+    "expo-image-picker": "~17.0.0",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import CustomImage from './screens/CustomImage';
 import Demo from './screens/Demo';
-import { SPACING } from './constants';
+import { COLORS, SPACING } from './constants';
 import { IMAGES } from './data';
 import PaletteExampleItem from './components/PaletteExampleItem';
 
@@ -64,7 +64,7 @@ export default function App() {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#fff',
+    backgroundColor: COLORS.background,
   },
   content: {
     padding: SPACING * 4,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,79 +1,29 @@
 import { useEffect, useState } from 'react';
 import {
   BackHandler,
-  Image,
   PlatformColor,
   Pressable,
   ScrollView,
   StatusBar,
   StyleSheet,
   Text,
-  View,
-  type ImageSourcePropType,
 } from 'react-native';
-import {
-  Palette,
-  type PaletteResult,
-  type PaletteTarget,
-} from 'react-native-material-palette';
-import Demo from './Demo';
-
-const PALETTE_TYPES: (keyof PaletteResult)[] = [
-  'vibrant',
-  'lightVibrant',
-  'darkVibrant',
-  'muted',
-  'lightMuted',
-  'darkMuted',
-];
-
-const IMAGES = [
-  {
-    source: require('../assets/images/ishan-seefromthesky.jpg'),
-    author: 'Ishan @seefromthesky',
-  },
-  {
-    source: require('../assets/images/mohamed-sameeh.jpg'),
-    author: 'Mohamed Sameeh',
-  },
-  {
-    source: require('../assets/images/andrew-pons.jpg'),
-    author: 'Andrew Pons',
-  },
-  {
-    source: require('../assets/images/luke-mummert.jpg'),
-    author: 'Luke Mummert',
-  },
-  {
-    source: require('../assets/images/paolo-nicolello.jpg'),
-    author: 'Paolo Nicolello',
-  },
-];
-
-const LIGHT_BACKGROUND_TARGET: PaletteTarget = {
-  targetLightness: 0.75,
-  minimumLightness: 0.65,
-  maximumLightness: 1.0,
-  targetSaturation: 0.1,
-  minimumSaturation: 0.0,
-  maximumSaturation: 0.6,
-  lightnessWeight: 0.5,
-  saturationWeight: 0.1,
-  populationWeight: 0.5,
-  exclusive: false,
-};
+import CustomImage from './screens/CustomImage';
+import Demo from './screens/Demo';
+import { SPACING } from './constants';
+import { IMAGES } from './data';
+import PaletteExampleItem from './components/PaletteExampleItem';
 
 const ROUNDNESS = 10;
-const SPACING = 8;
 
 export default function App() {
-  const [screen, setScreen] = useState<'home' | 'demo'>('home');
+  const [screen, setScreen] = useState<'home' | 'demo' | 'custom'>('home');
 
   useEffect(() => {
     const subscription = BackHandler.addEventListener(
       'hardwareBackPress',
       () => {
-        if (screen === 'demo') {
+        if (screen === 'demo' || screen === 'custom') {
           setScreen('home');
           return true;
         }
@@ -89,61 +39,26 @@ export default function App() {
     return <Demo />;
   }
 
+  if (screen === 'custom') {
+    return <CustomImage />;
+  }
+
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       {IMAGES.map((img, index) => (
-        <ExampleItem key={index} image={img.source} author={img.author} />
+        <PaletteExampleItem
+          key={index}
+          image={img.source}
+          author={img.author}
+        />
       ))}
       <Pressable style={styles.button} onPress={() => setScreen('demo')}>
         <Text style={styles.buttonLabel}>Go to Demo</Text>
       </Pressable>
+      <Pressable style={styles.button} onPress={() => setScreen('custom')}>
+        <Text style={styles.buttonLabel}>Build Demo from URL / gallery</Text>
+      </Pressable>
     </ScrollView>
-  );
-}
-
-function ExampleItem({
-  image,
-  author,
-}: {
-  image: ImageSourcePropType;
-  author: string;
-}) {
-  return (
-    <Palette.View
-      source={image}
-      type={LIGHT_BACKGROUND_TARGET}
-      style={styles.item}
-    >
-      <View style={styles.underlay} />
-      <View style={styles.row}>
-        <Image source={image} style={styles.image} resizeMode="cover" />
-        <View style={styles.palettes}>
-          {PALETTE_TYPES.map((type) => (
-            <View key={type} style={styles.palette}>
-              <Palette.View
-                key={type}
-                source={image}
-                type={type}
-                fallback={{
-                  color: '#ffffff',
-                  titleTextColor: '#000000',
-                  bodyTextColor: '#000000',
-                }}
-                style={styles.color}
-              >
-                <Palette.Text variant="titleTextColor" style={styles.title}>
-                  {type}
-                </Palette.Text>
-                <Palette.Text variant="bodyTextColor" style={styles.subtitle}>
-                  subtitle
-                </Palette.Text>
-              </Palette.View>
-            </View>
-          ))}
-        </View>
-      </View>
-      <Palette.Text style={styles.author}>Credits: {author}</Palette.Text>
-    </Palette.View>
   );
 }
 
@@ -152,15 +67,15 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   content: {
-    padding: SPACING * 2,
-    paddingTop: SPACING * 2 + (StatusBar.currentHeight ?? 0),
-    paddingBottom: SPACING * 2 + 10,
-    gap: SPACING * 2,
+    padding: SPACING * 4,
+    paddingTop: SPACING * 4 + (StatusBar.currentHeight ?? 0),
+    paddingBottom: SPACING * 4 + 10,
+    gap: SPACING * 4,
   },
   item: {
     width: '100%',
-    padding: SPACING,
-    borderRadius: ROUNDNESS + SPACING,
+    padding: SPACING * 2,
+    borderRadius: ROUNDNESS + SPACING * 2,
     overflow: 'hidden',
   },
   underlay: {
@@ -176,7 +91,7 @@ const styles = StyleSheet.create({
     height: null,
     width: null,
     borderRadius: ROUNDNESS,
-    margin: SPACING / 2,
+    margin: SPACING,
   },
   palettes: {
     flex: 1,
@@ -186,11 +101,11 @@ const styles = StyleSheet.create({
   },
   palette: {
     width: '50%',
-    padding: SPACING / 2,
+    padding: SPACING,
   },
   color: {
     alignItems: 'center',
-    padding: SPACING,
+    padding: SPACING * 2,
     borderRadius: ROUNDNESS,
     overflow: 'hidden',
   },
@@ -201,15 +116,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   author: {
-    margin: SPACING / 2,
+    margin: SPACING,
     fontStyle: 'italic',
   },
   button: {
-    marginVertical: SPACING,
     backgroundColor: PlatformColor('@android:color/system_accent1_50'),
-    paddingVertical: SPACING,
-    paddingHorizontal: SPACING * 2,
-    borderRadius: ROUNDNESS + SPACING,
+    paddingVertical: SPACING * 2,
+    paddingHorizontal: SPACING * 4,
+    borderRadius: ROUNDNESS + SPACING * 2,
   },
   buttonLabel: {
     textAlign: 'center',

--- a/example/src/components/PaletteExampleItem.tsx
+++ b/example/src/components/PaletteExampleItem.tsx
@@ -1,0 +1,108 @@
+import {
+  Image,
+  StyleSheet,
+  View,
+  type ImageSourcePropType,
+} from 'react-native';
+import { Palette } from 'react-native-material-palette';
+import { PALETTE_TYPES, LIGHT_BACKGROUND_TARGET, SPACING } from '../constants';
+
+const ROUNDNESS = 10;
+
+export default function PaleteExampleItem({
+  image,
+  author,
+}: {
+  image: ImageSourcePropType;
+  author?: string;
+}) {
+  return (
+    <Palette.View
+      source={image}
+      type={LIGHT_BACKGROUND_TARGET}
+      style={styles.item}
+    >
+      <View style={styles.underlay} />
+      <View style={styles.row}>
+        <Image source={image} style={styles.image} resizeMode="cover" />
+        <View style={styles.palettes}>
+          {PALETTE_TYPES.map((type) => (
+            <View key={type} style={styles.palette}>
+              <Palette.View
+                key={type}
+                source={image}
+                type={type}
+                fallback={{
+                  color: '#ffffff',
+                  titleTextColor: '#000000',
+                  bodyTextColor: '#000000',
+                }}
+                style={styles.color}
+              >
+                <Palette.Text variant="titleTextColor" style={styles.title}>
+                  {type}
+                </Palette.Text>
+                <Palette.Text variant="bodyTextColor" style={styles.subtitle}>
+                  subtitle
+                </Palette.Text>
+              </Palette.View>
+            </View>
+          ))}
+        </View>
+      </View>
+      {author ? (
+        <Palette.Text style={styles.author}>Credits: {author}</Palette.Text>
+      ) : null}
+    </Palette.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    width: '100%',
+    padding: SPACING * 2,
+    borderRadius: ROUNDNESS + SPACING * 2,
+    overflow: 'hidden',
+  },
+  underlay: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: '#e0e0e0',
+    mixBlendMode: 'luminosity',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  image: {
+    flexGrow: 1,
+    height: null,
+    width: null,
+    borderRadius: ROUNDNESS,
+    margin: SPACING,
+  },
+  palettes: {
+    flex: 1,
+    minWidth: 100,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  palette: {
+    width: '50%',
+    padding: SPACING,
+  },
+  color: {
+    alignItems: 'center',
+    padding: SPACING * 2,
+    borderRadius: ROUNDNESS,
+    overflow: 'hidden',
+  },
+  title: {
+    fontWeight: 'bold',
+  },
+  subtitle: {
+    fontSize: 14,
+  },
+  author: {
+    margin: SPACING,
+    fontStyle: 'italic',
+  },
+});

--- a/example/src/constants.ts
+++ b/example/src/constants.ts
@@ -1,0 +1,63 @@
+import {
+  type PaletteResult,
+  type PaletteTarget,
+} from 'react-native-material-palette';
+
+export const SPACING = 4;
+export const PADDING = SPACING * 5;
+export const GAP = SPACING * 3;
+export const ROUNDNESS = SPACING * 4;
+
+export const HERO_IMAGE_HEIGHT = SPACING * 55;
+
+export const STORY_IMAGE_WIDTH = SPACING * 28;
+export const STORY_IMAGE_HEIGHT = SPACING * 33;
+
+export const DOT_SIZE = SPACING * 1.5;
+export const DISCOVER_CARD_WIDTH_RATIO = 0.38;
+
+export const COLORS = {
+  background: '#FAFAFA',
+  text: '#1A1A1A',
+  subtitle: '#666',
+  fallbackDark: '#2A2A2A',
+  fallbackDarkTitle: '#FFFFFF',
+  fallbackDarkBody: '#CCCCCC',
+  fallbackLight: '#F0F0F0',
+  fallbackLightTitle: '#1A1A1A',
+  fallbackLightBody: '#555555',
+};
+
+export const FALLBACK_DARK = {
+  color: COLORS.fallbackDark,
+  titleTextColor: COLORS.fallbackDarkTitle,
+  bodyTextColor: COLORS.fallbackDarkBody,
+};
+
+export const FALLBACK_LIGHT = {
+  color: COLORS.fallbackLight,
+  titleTextColor: COLORS.fallbackLightTitle,
+  bodyTextColor: COLORS.fallbackLightBody,
+};
+
+export const PALETTE_TYPES: (keyof PaletteResult)[] = [
+  'vibrant',
+  'lightVibrant',
+  'darkVibrant',
+  'muted',
+  'lightMuted',
+  'darkMuted',
+];
+
+export const LIGHT_BACKGROUND_TARGET: PaletteTarget = {
+  targetLightness: 0.75,
+  minimumLightness: 0.65,
+  maximumLightness: 1.0,
+  targetSaturation: 0.1,
+  minimumSaturation: 0.0,
+  maximumSaturation: 0.6,
+  lightnessWeight: 0.5,
+  saturationWeight: 0.1,
+  populationWeight: 0.5,
+  exclusive: false,
+};

--- a/example/src/data.ts
+++ b/example/src/data.ts
@@ -1,0 +1,101 @@
+import type { DiscoverItem, HeroContent, StoryItem } from './types';
+
+// App
+export const IMAGES = [
+  {
+    source: require('../assets/images/ishan-seefromthesky.jpg'),
+    author: 'Ishan @seefromthesky',
+  },
+  {
+    source: require('../assets/images/mohamed-sameeh.jpg'),
+    author: 'Mohamed Sameeh',
+  },
+  {
+    source: require('../assets/images/andrew-pons.jpg'),
+    author: 'Andrew Pons',
+  },
+  {
+    source: require('../assets/images/luke-mummert.jpg'),
+    author: 'Luke Mummert',
+  },
+  {
+    source: require('../assets/images/paolo-nicolello.jpg'),
+    author: 'Paolo Nicolello',
+  },
+];
+
+// Demo screen
+export const HERO_ITEM: HeroContent = {
+  source: require('../assets/images/ishan-seefromthesky.jpg'),
+  title: 'Crystal Waters',
+  subtitle:
+    'Discover hidden paradise islands with pristine beaches and vibrant turquoise waters',
+  badgeText: 'Featured',
+};
+
+export const DISCOVER_ITEMS: DiscoverItem[] = [
+  {
+    source: require('../assets/images/mohamed-sameeh.jpg'),
+    title: 'Festival Lights',
+    location: 'Marrakech',
+  },
+  {
+    source: require('../assets/images/andrew-pons.jpg'),
+    title: 'Red Canyons',
+    location: 'Utah',
+  },
+  {
+    source: require('../assets/images/luke-mummert.jpg'),
+    title: 'Golden Gate',
+    location: 'San Francisco',
+  },
+  {
+    source: require('../assets/images/paolo-nicolello.jpg'),
+    title: 'Hidden Falls',
+    location: 'Iceland',
+  },
+];
+
+export const STORY_ITEMS: StoryItem[] = [
+  {
+    source: require('../assets/images/luke-mummert.jpg'),
+    title: 'Crossing the Golden Gate',
+    excerpt:
+      'A golden hour walk across the iconic bridge with the city skyline in the distance.',
+    meta: '8 min · Sarah Kim',
+  },
+  {
+    source: require('../assets/images/andrew-pons.jpg'),
+    title: 'Above the Red Canyons',
+    excerpt:
+      'Aerial views reveal sculpted sandstone labyrinths hidden beneath the clouds.',
+    meta: '5 min · James Chen',
+  },
+  {
+    source: require('../assets/images/paolo-nicolello.jpg'),
+    title: 'Chasing Waterfalls in Iceland',
+    excerpt:
+      'Moss-covered gorges, turquoise pools, and cascades carved into ancient rock.',
+    meta: '6 min · Elena Rossi',
+  },
+];
+
+// Custom image screen
+export const CUSTOM_HERO_ITEM = {
+  title: 'Lorem ipsum dolor sit amet',
+  subtitle:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  badgeText: 'Lorem',
+};
+
+export const STORY_ITEM = {
+  title: 'Lorem ipsum dolor',
+  excerpt:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  meta: 'Lorem · Ipsum',
+};
+
+export const DISCOVER_ITEM = {
+  title: 'Lorem ipsum',
+  location: 'Dolor sit amet',
+};

--- a/example/src/screens/CustomImage.tsx
+++ b/example/src/screens/CustomImage.tsx
@@ -1,0 +1,230 @@
+import * as ImagePicker from 'expo-image-picker';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentRef,
+} from 'react';
+import {
+  Alert,
+  Image,
+  Keyboard,
+  PlatformColor,
+  Pressable,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type LayoutChangeEvent,
+  type ImageSourcePropType,
+} from 'react-native';
+import Demo from './Demo';
+import { CUSTOM_HERO_ITEM, DISCOVER_ITEM, STORY_ITEM } from '../data';
+import { PADDING, SPACING, GAP, ROUNDNESS, COLORS } from '../constants';
+import PaletteExampleItem from '../components/PaletteExampleItem';
+
+export default function CustomImage() {
+  const [imageSource, setImageSource] = useState<ImageSourcePropType | null>(
+    null
+  );
+  const [urlInput, setUrlInput] = useState('');
+  const [isLoadingImage, setIsLoadingImage] = useState(false);
+  const [demoOffsetY, setDemoOffsetY] = useState<number | null>(null);
+  const scrollViewRef = useRef<ComponentRef<typeof ScrollView>>(null);
+
+  useEffect(() => {
+    if (!imageSource || demoOffsetY === null) return;
+
+    requestAnimationFrame(() => {
+      scrollViewRef.current?.scrollTo({
+        y: Math.max(demoOffsetY, 0),
+        animated: true,
+      });
+    });
+  }, [demoOffsetY, imageSource]);
+
+  const loadImageFromUri = useCallback((uri: string, errorMessage: string) => {
+    setIsLoadingImage(true);
+    Image.getSize(
+      uri,
+      () => {
+        setImageSource({ uri });
+        setIsLoadingImage(false);
+      },
+      () => {
+        setIsLoadingImage(false);
+        Alert.alert('Image error', errorMessage);
+      }
+    );
+  }, []);
+
+  const pickFromGallery = useCallback(async () => {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsEditing: false,
+        quality: 1,
+      });
+      if (!result.canceled && result.assets[0]?.uri) {
+        loadImageFromUri(
+          result.assets[0].uri,
+          'Selected file could not be loaded as an image.'
+        );
+      }
+    } catch {
+      Alert.alert('Image error', 'Could not open image picker.');
+    }
+  }, [loadImageFromUri]);
+
+  const loadFromUrl = useCallback(() => {
+    Keyboard.dismiss();
+    const trimmed = urlInput.trim();
+    if (!trimmed) return;
+
+    try {
+      const parsed = new URL(trimmed);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        Alert.alert(
+          'Invalid URL',
+          'Please provide an HTTP or HTTPS image URL.'
+        );
+        return;
+      }
+      loadImageFromUri(
+        parsed.toString(),
+        'Could not load image from this URL.'
+      );
+    } catch {
+      Alert.alert('Invalid URL', 'Please provide a valid image URL.');
+    }
+  }, [loadImageFromUri, urlInput]);
+
+  const handleDemoLayout = useCallback((event: LayoutChangeEvent) => {
+    setDemoOffsetY(event.nativeEvent.layout.y);
+  }, []);
+
+  return (
+    <View style={styles.screen}>
+      <StatusBar barStyle="dark-content" backgroundColor={COLORS.background} />
+      <ScrollView
+        ref={scrollViewRef}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+      >
+        <Text style={styles.header}>Custom image</Text>
+        <Text style={styles.subtitle}>
+          Load from URL or gallery. Demo preview appears after image is loaded.
+        </Text>
+        <View style={styles.controlsCard}>
+          <Text style={styles.label}>Image URL</Text>
+          <TextInput
+            style={styles.input}
+            value={urlInput}
+            onChangeText={setUrlInput}
+            placeholder="https://example.com/image.jpg"
+            placeholderTextColor={COLORS.subtitle}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+          />
+          <Pressable style={styles.button} onPress={loadFromUrl}>
+            <Text style={styles.buttonLabel}>
+              {isLoadingImage ? 'Loading image...' : 'Load from URL'}
+            </Text>
+          </Pressable>
+
+          <Pressable style={styles.button} onPress={pickFromGallery}>
+            <Text style={styles.buttonLabel}>Pick from gallery</Text>
+          </Pressable>
+        </View>
+        {imageSource ? (
+          <View onLayout={handleDemoLayout}>
+            <Demo
+              sourceOverride={imageSource}
+              content={{
+                hero: { ...CUSTOM_HERO_ITEM, source: imageSource },
+                discover: { ...DISCOVER_ITEM, source: imageSource },
+                stories: { ...STORY_ITEM, source: imageSource },
+              }}
+            />
+            <Text style={styles.header}>Palette</Text>
+            <View style={styles.paletteContainer}>
+              <PaletteExampleItem image={imageSource} />
+            </View>
+          </View>
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: COLORS.background,
+  },
+  scrollContent: {
+    paddingTop: (StatusBar.currentHeight ?? 0) + PADDING,
+    paddingBottom: PADDING * 2,
+  },
+  paletteContainer: {
+    padding: SPACING * 4,
+  },
+  header: {
+    fontSize: 34,
+    fontWeight: '800',
+    color: COLORS.text,
+    marginHorizontal: PADDING,
+    marginBottom: SPACING * 3,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: COLORS.subtitle,
+    marginHorizontal: PADDING,
+    marginBottom: PADDING,
+  },
+  controlsCard: {
+    marginHorizontal: PADDING,
+    borderRadius: ROUNDNESS,
+    padding: GAP,
+    gap: SPACING,
+    backgroundColor: COLORS.background,
+    zIndex: 2,
+    elevation: 1,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: COLORS.text,
+    marginBottom: SPACING / 2,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: ROUNDNESS,
+    paddingHorizontal: GAP,
+    paddingVertical: SPACING * 2,
+    fontSize: 14,
+    color: COLORS.text,
+    marginBottom: SPACING * 2,
+    backgroundColor: COLORS.background,
+  },
+  button: {
+    marginVertical: SPACING / 2,
+    backgroundColor: PlatformColor('@android:color/system_accent1_50'),
+    paddingVertical: SPACING * 2,
+    paddingHorizontal: GAP,
+    borderRadius: ROUNDNESS + SPACING,
+    alignItems: 'center',
+  },
+  buttonLabel: {
+    textAlign: 'center',
+    color: PlatformColor('@android:color/system_accent1_700'),
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/example/src/screens/CustomImage.tsx
+++ b/example/src/screens/CustomImage.tsx
@@ -106,6 +106,8 @@ export default function CustomImage() {
     setDemoOffsetY(event.nativeEvent.layout.y);
   }, []);
 
+  const loadFromUrlDisabled = !urlInput.trim() || isLoadingImage;
+
   return (
     <View style={styles.screen}>
       <StatusBar barStyle="dark-content" backgroundColor={COLORS.background} />
@@ -123,7 +125,7 @@ export default function CustomImage() {
           <Text style={styles.label}>Image URL</Text>
           <TextInput
             style={styles.input}
-            value={urlInput}
+            defaultValue={urlInput}
             onChangeText={setUrlInput}
             placeholder="https://example.com/image.jpg"
             placeholderTextColor={COLORS.subtitle}
@@ -131,13 +133,22 @@ export default function CustomImage() {
             autoCorrect={false}
             keyboardType="url"
           />
-          <Pressable style={styles.button} onPress={loadFromUrl}>
-            <Text style={styles.buttonLabel}>
-              {isLoadingImage ? 'Loading image...' : 'Load from URL'}
-            </Text>
+          <Pressable
+            style={[
+              styles.button,
+              loadFromUrlDisabled && styles.buttonDisabled,
+            ]}
+            onPress={loadFromUrl}
+            disabled={loadFromUrlDisabled}
+          >
+            <Text style={styles.buttonLabel}>Load from URL</Text>
           </Pressable>
 
-          <Pressable style={styles.button} onPress={pickFromGallery}>
+          <Pressable
+            style={[styles.button, isLoadingImage && styles.buttonDisabled]}
+            onPress={pickFromGallery}
+            disabled={isLoadingImage}
+          >
             <Text style={styles.buttonLabel}>Pick from gallery</Text>
           </Pressable>
         </View>
@@ -220,6 +231,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: GAP,
     borderRadius: ROUNDNESS + SPACING,
     alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
   },
   buttonLabel: {
     textAlign: 'center',

--- a/example/src/screens/CustomImage.tsx
+++ b/example/src/screens/CustomImage.tsx
@@ -25,6 +25,7 @@ import Demo from './Demo';
 import { CUSTOM_HERO_ITEM, DISCOVER_ITEM, STORY_ITEM } from '../data';
 import { PADDING, SPACING, GAP, ROUNDNESS, COLORS } from '../constants';
 import PaletteExampleItem from '../components/PaletteExampleItem';
+import type { CustomDemoProps } from '../types';
 
 export default function CustomImage() {
   const [imageSource, setImageSource] = useState<ImageSourcePropType | null>(
@@ -162,13 +163,7 @@ export default function CustomImage() {
   );
 }
 
-function CustomDemo({
-  imageSource,
-  onLayout,
-}: {
-  imageSource: ImageSourcePropType;
-  onLayout: (event: LayoutChangeEvent) => void;
-}) {
+function CustomDemo({ imageSource, onLayout }: CustomDemoProps) {
   const demoContent = {
     hero: { ...CUSTOM_HERO_ITEM, source: imageSource },
     discover: { ...DISCOVER_ITEM, source: imageSource },

--- a/example/src/screens/CustomImage.tsx
+++ b/example/src/screens/CustomImage.tsx
@@ -132,6 +132,8 @@ export default function CustomImage() {
             autoCapitalize="none"
             autoCorrect={false}
             keyboardType="url"
+            returnKeyType="done"
+            onSubmitEditing={loadFromUrl}
           />
           <Pressable
             style={[
@@ -153,22 +155,33 @@ export default function CustomImage() {
           </Pressable>
         </View>
         {imageSource ? (
-          <View onLayout={handleDemoLayout}>
-            <Demo
-              sourceOverride={imageSource}
-              content={{
-                hero: { ...CUSTOM_HERO_ITEM, source: imageSource },
-                discover: { ...DISCOVER_ITEM, source: imageSource },
-                stories: { ...STORY_ITEM, source: imageSource },
-              }}
-            />
-            <Text style={styles.header}>Palette</Text>
-            <View style={styles.paletteContainer}>
-              <PaletteExampleItem image={imageSource} />
-            </View>
-          </View>
+          <CustomDemo imageSource={imageSource} onLayout={handleDemoLayout} />
         ) : null}
       </ScrollView>
+    </View>
+  );
+}
+
+function CustomDemo({
+  imageSource,
+  onLayout,
+}: {
+  imageSource: ImageSourcePropType;
+  onLayout: (event: LayoutChangeEvent) => void;
+}) {
+  const demoContent = {
+    hero: { ...CUSTOM_HERO_ITEM, source: imageSource },
+    discover: { ...DISCOVER_ITEM, source: imageSource },
+    stories: { ...STORY_ITEM, source: imageSource },
+  };
+
+  return (
+    <View onLayout={onLayout}>
+      <Demo sourceOverride={imageSource} content={demoContent} />
+      <Text style={styles.header}>Palette</Text>
+      <View style={styles.paletteContainer}>
+        <PaletteExampleItem image={imageSource} />
+      </View>
     </View>
   );
 }

--- a/example/src/screens/Demo.tsx
+++ b/example/src/screens/Demo.tsx
@@ -6,104 +6,46 @@ import {
   Text,
   View,
   useWindowDimensions,
-  type ImageSourcePropType,
 } from 'react-native';
 import { Palette } from 'react-native-material-palette';
+import { HERO_ITEM, DISCOVER_ITEMS, STORY_ITEMS } from '../data';
+import type { DemoProps, DiscoverItem, HeroContent, StoryItem } from '../types';
+import {
+  PADDING,
+  SPACING,
+  GAP,
+  ROUNDNESS,
+  HERO_IMAGE_HEIGHT,
+  STORY_IMAGE_WIDTH,
+  STORY_IMAGE_HEIGHT,
+  DOT_SIZE,
+  DISCOVER_CARD_WIDTH_RATIO,
+  COLORS,
+  FALLBACK_DARK,
+  FALLBACK_LIGHT,
+} from '../constants';
 
-const DISCOVER_CARD_WIDTH_RATIO = 0.38;
+const toArray = <T,>(value: T | T[]) =>
+  Array.isArray(value) ? value : [value];
 
-const COLORS = {
-  background: '#FAFAFA',
-  text: '#1A1A1A',
-  fallbackDark: '#2A2A2A',
-  fallbackDarkTitle: '#FFFFFF',
-  fallbackDarkBody: '#CCCCCC',
-  fallbackLight: '#F0F0F0',
-  fallbackLightTitle: '#1A1A1A',
-  fallbackLightBody: '#555555',
-};
+export default function Demo({ sourceOverride, content }: DemoProps) {
+  const {
+    hero = HERO_ITEM,
+    discover = DISCOVER_ITEMS,
+    stories = STORY_ITEMS,
+  } = content ?? {};
 
-const SPACING = 4;
-const PADDING = SPACING * 5;
-const GAP = SPACING * 3;
-const ROUNDNESS = SPACING * 4;
-const HERO_IMAGE_HEIGHT = SPACING * 55;
-const STORY_IMAGE_WIDTH = SPACING * 28;
-const STORY_IMAGE_HEIGHT = SPACING * 33;
-const DOT_SIZE = SPACING * 1.5;
-
-const FALLBACK_DARK = {
-  color: COLORS.fallbackDark,
-  titleTextColor: COLORS.fallbackDarkTitle,
-  bodyTextColor: COLORS.fallbackDarkBody,
-};
-
-const FALLBACK_LIGHT = {
-  color: COLORS.fallbackLight,
-  titleTextColor: COLORS.fallbackLightTitle,
-  bodyTextColor: COLORS.fallbackLightBody,
-};
-
-const HERO_IMAGE = require('../assets/images/ishan-seefromthesky.jpg');
-
-const DISCOVER_ITEMS = [
-  {
-    source: require('../assets/images/mohamed-sameeh.jpg'),
-    title: 'Festival Lights',
-    location: 'Marrakech',
-  },
-  {
-    source: require('../assets/images/andrew-pons.jpg'),
-    title: 'Red Canyons',
-    location: 'Utah',
-  },
-  {
-    source: require('../assets/images/luke-mummert.jpg'),
-    title: 'Golden Gate',
-    location: 'San Francisco',
-  },
-  {
-    source: require('../assets/images/paolo-nicolello.jpg'),
-    title: 'Hidden Falls',
-    location: 'Iceland',
-  },
-];
-
-const STORY_ITEMS = [
-  {
-    source: require('../assets/images/luke-mummert.jpg'),
-    title: 'Crossing the Golden Gate',
-    excerpt:
-      'A golden hour walk across the iconic bridge with the city skyline in the distance.',
-    meta: '8 min · Sarah Kim',
-  },
-  {
-    source: require('../assets/images/andrew-pons.jpg'),
-    title: 'Above the Red Canyons',
-    excerpt:
-      'Aerial views reveal sculpted sandstone labyrinths hidden beneath the clouds.',
-    meta: '5 min · James Chen',
-  },
-  {
-    source: require('../assets/images/paolo-nicolello.jpg'),
-    title: 'Chasing Waterfalls in Iceland',
-    excerpt:
-      'Moss-covered gorges, turquoise pools, and cascades carved into ancient rock.',
-    meta: '6 min · Elena Rossi',
-  },
-];
-
-export default function Demo() {
   return (
     <View style={styles.screen}>
       <StatusBar barStyle="dark-content" backgroundColor={COLORS.background} />
       <ScrollView
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={
+          content ? styles.scrollContent : styles.scrollNoContent
+        }
         showsVerticalScrollIndicator={false}
       >
         <Text style={styles.header}>Explore</Text>
-
-        <HeroCard />
+        <HeroCard {...hero} />
 
         <Text style={styles.sectionTitle}>Discover</Text>
         <ScrollView
@@ -111,61 +53,63 @@ export default function Demo() {
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.discoverScroll}
         >
-          {DISCOVER_ITEMS.map((item, i) => (
-            <DiscoverCard key={i} {...item} />
+          {toArray(discover).map((item, i) => (
+            <DiscoverCard
+              key={i}
+              source={sourceOverride ?? item.source}
+              title={item.title}
+              location={item.location}
+            />
           ))}
         </ScrollView>
 
         <Text style={styles.sectionTitle}>Stories</Text>
-        {STORY_ITEMS.map((item, i) => (
-          <StoryCard key={i} {...item} />
+        {toArray(stories).map((item, i) => (
+          <StoryCard
+            key={i}
+            source={sourceOverride ?? item.source}
+            title={item.title}
+            excerpt={item.excerpt}
+            meta={item.meta}
+          />
         ))}
       </ScrollView>
     </View>
   );
 }
 
-function HeroCard() {
+function HeroCard({ source, title, subtitle, badgeText }: HeroContent) {
   return (
     <Palette.View
-      source={HERO_IMAGE}
+      source={source}
       type="darkMuted"
       fallback={FALLBACK_DARK}
       style={styles.heroCard}
     >
-      <Image source={HERO_IMAGE} style={styles.heroImage} resizeMode="cover" />
+      <Image source={source} style={styles.heroImage} resizeMode="cover" />
       <View style={styles.heroContent}>
         <Palette.View
-          source={HERO_IMAGE}
+          source={source}
           type="vibrant"
           fallback={FALLBACK_DARK}
           style={styles.badge}
         >
           <Palette.Text variant="titleTextColor" style={styles.badgeText}>
-            Featured
+            {badgeText}
           </Palette.Text>
         </Palette.View>
         <Palette.Text variant="titleTextColor" style={styles.heroTitle}>
-          Crystal Waters
+          {title}
         </Palette.Text>
         <Palette.Text variant="bodyTextColor" style={styles.heroSubtitle}>
-          Discover hidden paradise islands with pristine beaches and vibrant
-          turquoise waters
+          {subtitle}
         </Palette.Text>
       </View>
     </Palette.View>
   );
 }
 
-function DiscoverCard({
-  source,
-  title,
-  location,
-}: {
-  source: ImageSourcePropType;
-  title: string;
-  location: string;
-}) {
+function DiscoverCard({ source, title, location }: DiscoverItem) {
   const { width } = useWindowDimensions();
   const cardWidth = width * DISCOVER_CARD_WIDTH_RATIO;
 
@@ -193,17 +137,7 @@ function DiscoverCard({
   );
 }
 
-function StoryCard({
-  source,
-  title,
-  excerpt,
-  meta,
-}: {
-  source: ImageSourcePropType;
-  title: string;
-  excerpt: string;
-  meta: string;
-}) {
+function StoryCard({ source, title, excerpt, meta }: StoryItem) {
   return (
     <Palette.View
       source={source}
@@ -249,10 +183,27 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.background,
   },
   scrollContent: {
+    paddingTop: PADDING * 2,
+    paddingBottom: PADDING,
+  },
+  scrollNoContent: {
     paddingTop: (StatusBar.currentHeight ?? 0) + PADDING,
     paddingBottom: PADDING * 2,
   },
   header: {
+    fontSize: 34,
+    fontWeight: '800',
+    color: COLORS.text,
+    marginHorizontal: PADDING,
+    marginBottom: SPACING * 3,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: COLORS.subtitle,
+    marginHorizontal: PADDING,
+    marginBottom: PADDING,
+  },
+  contentHeader: {
     fontSize: 34,
     fontWeight: '800',
     color: COLORS.text,

--- a/example/src/types.ts
+++ b/example/src/types.ts
@@ -1,4 +1,4 @@
-import type { ImageSourcePropType } from 'react-native';
+import type { ImageSourcePropType, LayoutChangeEvent } from 'react-native';
 
 export type HeroContent = {
   source: ImageSourcePropType;
@@ -27,4 +27,9 @@ export type DemoProps = {
     discover: DiscoverItem | DiscoverItem[];
     stories: StoryItem | StoryItem[];
   };
+};
+
+export type CustomDemoProps = {
+  imageSource: ImageSourcePropType;
+  onLayout: (event: LayoutChangeEvent) => void;
 };

--- a/example/src/types.ts
+++ b/example/src/types.ts
@@ -1,0 +1,30 @@
+import type { ImageSourcePropType } from 'react-native';
+
+export type HeroContent = {
+  source: ImageSourcePropType;
+  title: string;
+  subtitle: string;
+  badgeText: string;
+};
+
+export type DiscoverItem = {
+  source: ImageSourcePropType;
+  title: string;
+  location: string;
+};
+
+export type StoryItem = {
+  source: ImageSourcePropType;
+  title: string;
+  excerpt: string;
+  meta: string;
+};
+
+export type DemoProps = {
+  sourceOverride?: ImageSourcePropType;
+  content?: {
+    hero: HeroContent;
+    discover: DiscoverItem | DiscoverItem[];
+    stories: StoryItem | StoryItem[];
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6131,6 +6131,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-image-loader@npm:~6.0.0":
+  version: 6.0.0
+  resolution: "expo-image-loader@npm:6.0.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/36f1e80d2b3d2a1cce440c7d938cd3cf3138f2b1fa706a1954e415bfae87b5b8eeaec65be0ab17880eb7585dd28c9225d056ebdb98ac81e0ffbfe880d952b0eb
+  languageName: node
+  linkType: hard
+
+"expo-image-picker@npm:~17.0.0":
+  version: 17.0.10
+  resolution: "expo-image-picker@npm:17.0.10"
+  dependencies:
+    expo-image-loader: "npm:~6.0.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/d05ed6ce53463acc86af062df33a648aaafb27549f875ebf907f0f438c09727ae9b75fb8c333fdcaceb0249d9de16929d2cd65ba81f256403745a30af9a7f8c3
+  languageName: node
+  linkType: hard
+
 "expo-json-utils@npm:~0.15.0":
   version: 0.15.0
   resolution: "expo-json-utils@npm:0.15.0"
@@ -10120,6 +10140,7 @@ __metadata:
   dependencies:
     expo: "npm:~54.0.32"
     expo-dev-client: "npm:~6.0.20"
+    expo-image-picker: "npm:~17.0.0"
     expo-status-bar: "npm:~3.0.9"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Added a new Custom Image screen in the example app, which allow to extract colors from loaded image via
provided URL or the device gallery.

https://github.com/user-attachments/assets/c7641563-5415-4efa-98f8-19e019ac836b




<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
